### PR TITLE
Apply sm layout for Contact section at md range

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -247,3 +247,19 @@
   }
 }
 
+@media (min-width: 768px) and (max-width: 1023px) {
+  #shopify-section-template--26262035235155__contact-form .md\:flex {
+    display: block;
+  }
+  #shopify-section-template--26262035235155__contact-form .md\:-mx-4 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  #shopify-section-template--26262035235155__contact-form .md\:w-3\/12 {
+    width: 100%;
+  }
+  #shopify-section-template--26262035235155__contact-form .md\:px-4 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}

--- a/sections/contact-form.liquid
+++ b/sections/contact-form.liquid
@@ -54,10 +54,14 @@
                 <h3 class="font-medium mb-5 text-lg">{{ bs.title }}</h3>
                 <div style="color: var(--color-secondary);">{{ bs.content }}</div>
               </div>
-            {% else %}
+            {% when 'socialmedia' %}
               <div class="md:w-3/12 md:px-4 xl:w-full xl:px-0 sf__text-block mb-7">
                 <h3 class="font-medium mb-5 text-lg">{{ bs.title }}</h3>
                 <div class="-mx-4">{% render 'social-media-links' %}</div>
+              </div>
+            {% when 'custom_liquid' %}
+              <div class="md:w-3/12 md:px-4 xl:w-full xl:px-0 sf__text-block mb-7">
+                {{ bs.code }}
               </div>
           {% endcase %}
         {% endfor %}
@@ -157,6 +161,17 @@
           "id": "title",
           "label": "Title",
           "default": "Social Media"
+        }
+      ]
+    },
+    {
+      "type": "custom_liquid",
+      "name": "Custom liquid",
+      "settings": [
+        {
+          "type": "liquid",
+          "id": "code",
+          "label": "Code"
         }
       ]
     }

--- a/templates/page.contact.json
+++ b/templates/page.contact.json
@@ -38,6 +38,12 @@
             "content": "<p>0729 554 378<br/></p><p>egross.romania@gmail.com</p>"
           }
         },
+        "custom_liquid_fiXFhf": {
+          "type": "custom_liquid",
+          "settings": {
+            "code": "<div class=\"eg-contact-map\">\n  <div class=\"eg-map-embed\">\n    <iframe\n      src=\"https://www.google.com/maps?q=44.4919694,26.1901967&z=18&output=embed\"\n      style=\"border:0;\" allowfullscreen loading=\"lazy\"\n      referrerpolicy=\"no-referrer-when-downgrade\">\n    </iframe>\n    <!-- întregul iframe devine clickabil -->\n    <a class=\"eg-map-overlay\"\n       href=\"https://www.google.com/maps/search/?api=1&query=44.4919694,26.1901967\"\n       target=\"_blank\" rel=\"noopener noreferrer\"\n       aria-label=\"Deschide pe Google Maps\"></a>\n  </div>\n\n  <a class=\"eg-map-link\"\n     href=\"https://www.google.com/maps/search/?api=1&query=44.4919694,26.1901967\"\n     target=\"_blank\" rel=\"noopener noreferrer\">\n     Vezi locația pe Google Maps\n  </a>\n</div>\n\n<style>\n  .eg-contact-map { display:block; }\n  .eg-map-embed { position:relative; width:100%; aspect-ratio:16/9; }\n  .eg-map-embed iframe { position:absolute; inset:0; width:100%; height:100%; }\n  .eg-map-overlay { position:absolute; inset:0; display:block; }\n  .eg-map-link { display:inline-block; margin-top:8px; text-decoration:underline; }\n</style>"
+          }
+        },
         "text-block-3": {
           "type": "socialmedia",
           "disabled": true,
@@ -57,6 +63,7 @@
       "block_order": [
         "text-block-1",
         "text-block-2",
+        "custom_liquid_fiXFhf",
         "text-block-3",
         "text-block-4"
       ],
@@ -68,20 +75,11 @@
         "show_phone": true,
         "show_signup_email": false
       }
-    },
-    "custom_liquid_q7RLBR": {
-      "type": "custom-liquid",
-      "name": "Custom liquid",
-      "settings": {
-        "custom_liquid": "<div class=\"eg-contact-map\">\n  <div class=\"eg-map-embed\">\n    <iframe\n      src=\"https://www.google.com/maps?q=44.4268,26.1025&z=15&output=embed\"\n      style=\"border:0;\" allowfullscreen=\"\" loading=\"lazy\" referrerpolicy=\"no-referrer-when-downgrade\">\n    </iframe>\n    <a class=\"eg-map-overlay\" href=\"https://www.google.com/maps?q=44.4268,26.1025\" target=\"_blank\" rel=\"noopener\" aria-label=\"Deschide pe Google Maps\"></a>\n  </div>\n  <a class=\"eg-map-link\" href=\"https://www.google.com/maps?q=44.4268,26.1025\" target=\"_blank\" rel=\"noopener\">Vezi locația pe Google Maps</a>\n</div>\n\n<style>\n  .eg-contact-map { display:block; }\n  .eg-map-embed { position:relative; width:100%; aspect-ratio:16/9; }\n  .eg-map-embed iframe { position:absolute; inset:0; width:100%; height:100%; }\n  /* overlay face tot iframe-ul „click to open in new tab” */\n  .eg-map-overlay { position:absolute; inset:0; display:block; }\n  .eg-map-link { display:inline-block; margin-top:8px; text-decoration:underline; }\n</style>",
-        "custom_class": ""
-      }
     }
   },
   "order": [
     "main",
     "7b5d32cd-b203-40e5-b30a-64a5066dd4f8",
-    "contact-form",
-    "custom_liquid_q7RLBR"
+    "contact-form"
   ]
 }


### PR DESCRIPTION
## Summary
- override md range (768-1023px) for Contact form side blocks to mimic small-screen layout

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/egross-14.2/package.json')*
- `theme-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b77228f8a8832da20ea9175c84a941