### PR TITLE
Refactor contact info layout for md breakpoint

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -53,3 +53,27 @@
     width:auto;
   }
 }
+/* Contact info grid responsive overrides */
+@media (min-width:768px) and (max-width:1023px){
+  section[data-section-type="contact-page"] .contact-info-grid{
+    flex-direction:column;
+    flex-wrap:nowrap;
+    row-gap:1.25rem;
+    margin-left:0;
+    margin-right:0;
+    overflow:visible;
+    margin-bottom:var(--space,1.5rem);
+  }
+  section[data-section-type="contact-page"] .contact-info-grid > *{
+    width:100%;
+    margin-left:0;
+    margin-right:0;
+    padding-left:0;
+    padding-right:0;
+  }
+}
+section[data-section-type="contact-page"] .contact-info-grid iframe{
+  max-width:100% !important;
+  height:auto !important;
+  display:block;
+}

--- a/sections/contact-form.liquid
+++ b/sections/contact-form.liquid
@@ -45,7 +45,7 @@
         {%- endform -%}
       </div>
       {% if section.blocks.size > 0 %}
-      <div class="w-full md:flex md:-mx-4 xl:mx-0 xl:w-4/12 xl:block xl:mb-0 mb-7">
+      <div class="contact-info-grid w-full md:flex md:-mx-4 xl:mx-0 xl:w-4/12 xl:block xl:mb-0 mb-7">
         {% for block in section.blocks %}
           {% assign bs = block.settings %}
           {% case block.type %}


### PR DESCRIPTION
## Summary
- add `contact-info-grid` wrapper for contact details on contact page
- stack contact info items vertically between 768px and 1023px and ensure responsive map

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b78cc53084832dac0d5d2b2ba2a85a