### PR TITLE
Refactor contact info layout and fix contact map overlay

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -53,3 +53,60 @@
     width:auto;
   }
 }
+/* Contact info grid responsive overrides */
+@media (min-width:768px) and (max-width:1023px){
+  section[data-section-type="contact-page"] .contact-info-grid{
+    flex-direction:column;
+    flex-wrap:nowrap;
+    row-gap:1.25rem;
+    margin-left:0;
+    margin-right:0;
+    overflow:visible;
+    margin-bottom:var(--space,1.5rem);
+  }
+  section[data-section-type="contact-page"] .contact-info-grid > *{
+    width:100%;
+    margin-left:0;
+    margin-right:0;
+    padding-left:0;
+    padding-right:0;
+  }
+}
+section[data-section-type="contact-page"] .contact-info-grid iframe{
+  max-width:100% !important;
+  height:auto !important;
+  display:block;
+}
+
+/* CONTACT — Map responsive & overlay fix */
+section[data-section-type="contact-page"] .eg-map-embed{
+  position:relative;
+  width:100%;
+  max-width:100%;
+  aspect-ratio:16/9;
+  overflow:hidden;
+}
+section[data-section-type="contact-page"] .eg-map-embed>iframe{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
+  border:0;
+  display:block;
+}
+section[data-section-type="contact-page"] .eg-map-overlay{
+  position:absolute;
+  inset:0;
+  display:block;
+  background:transparent;
+  height:auto !important;
+  width:100% !important;
+}
+@media (max-width:1023px){
+  section[data-section-type="contact-page"] .eg-contact-map{
+    margin-bottom:1.25rem;
+  }
+  section[data-section-type="contact-page"] .eg-map-embed{
+    aspect-ratio:4/3;
+  }
+}

--- a/sections/contact-form.liquid
+++ b/sections/contact-form.liquid
@@ -45,7 +45,7 @@
         {%- endform -%}
       </div>
       {% if section.blocks.size > 0 %}
-      <div class="w-full md:flex md:-mx-4 xl:mx-0 xl:w-4/12 xl:block xl:mb-0 mb-7">
+      <div class="contact-info-grid w-full md:flex md:-mx-4 xl:mx-0 xl:w-4/12 xl:block xl:mb-0 mb-7">
         {% for block in section.blocks %}
           {% assign bs = block.settings %}
           {% case block.type %}


### PR DESCRIPTION
## Summary
- add `contact-info-grid` wrapper for contact details on contact page
- stack contact info items vertically between 768px and 1023px
- ensure responsive map embed and overlay below 1024px

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b78cc53084832dac0d5d2b2ba2a85a