### PR TITLE
fix contact map sizing

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -72,8 +72,24 @@
     padding-right:0;
   }
 }
-section[data-section-type="contact-page"] .contact-info-grid iframe{
-  max-width:100% !important;
-  height:auto !important;
-  display:block;
+/* CONTACT — Map container keeps aspect; iframe fills it */
+section[data-section-type="contact-page"] .eg-map-embed{
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+}
+section[data-section-type="contact-page"] .eg-map-embed > iframe{
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+section[data-section-type="contact-page"] .eg-map-overlay{
+  position: absolute;
+  inset: 0;
+  display: block;
+  background: transparent;
 }


### PR DESCRIPTION
## Summary
- remove incorrect height override on contact-page map iframe
- ensure contact map container preserves 16:9 aspect and iframe fills container
- keep optional map overlay nonintrusive

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b79207f278832d8a760017054928bf