### PR TITLE
ATC (colecții) — inline right (auto width) + stacked 100% la wrap, fără modificări de markup.

### DIFF
--- a/assets/collection-quick-add.css
+++ b/assets/collection-quick-add.css
@@ -83,3 +83,35 @@ input.collection-qty-element:focus {
   font-weight: 600;
 }
 
+/* === ATC inline (colecții) — aliniere dreapta + width:auto === */
+[data-collection-cart-actions] {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 0.5rem; /* păstrează un mic spațiu între grupuri */
+}
+
+/* Qty wrapper ia spațiul disponibil; ATC stă la dreapta */
+[data-collection-cart-actions] .collection-qty-wrapper {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* Impunem ATC inline spre dreapta, width:auto; anulăm w-full din markup */
+[data-collection-cart-actions] .collection-add-to-cart {
+  width: auto !important;
+  margin-left: auto;           /* „lipit” la dreapta */
+  margin-top: 0 !important;    /* anulăm .mt-4 când suntem inline */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* asigură comportament previzibil la îngustare */
+  min-width: max(140px, fit-content);
+}
+
+/* === Mod „stacked” când qty+double-qty se rup pe 2 rânduri === */
+[data-collection-cart-actions].is-stacked .collection-add-to-cart {
+  width: 100% !important;
+  margin-left: 0;
+  margin-top: 0.75rem !important; /* simulăm ușor spațiul de deasupra, ca vechiul mt-4 */
+}

--- a/assets/collection-quick-add.js
+++ b/assets/collection-quick-add.js
@@ -678,12 +678,22 @@ async function handleDelegatedAddToCart(e){
     var btn = e.target.closest('.collection-double-qty-btn');
     if(btn) btn.classList.remove('focus');
   }
+  function syncActionsStackState(qtyGroupEl) {
+    try {
+      var actions = qtyGroupEl.closest('[data-collection-cart-actions]');
+      if (!actions) return;
+      var wrapped = qtyGroupEl.classList.contains('is-wrapped');
+      actions.classList.toggle('is-stacked', wrapped);
+    } catch (e) { /* noop */ }
+  }
   function updateQtyGroupLayout(){
     document.querySelectorAll('.collection-qty-group').forEach(function(group){
       var input = group.querySelector('input[data-collection-quantity-input]');
       var btn = group.querySelector('.collection-double-qty-btn');
       if(!input || !btn) return;
-      group.classList.toggle('is-wrapped', btn.offsetTop > input.offsetTop);
+      var wrapped = btn.offsetTop > input.offsetTop;
+      group.classList.toggle('is-wrapped', wrapped);
+      syncActionsStackState(group);
     });
   }
   var qtyLayoutListenerBound = false;


### PR DESCRIPTION
## Summary
- Align collection Add to Cart button to the right with auto width; stack full-width when quantity group wraps
- Propagate quantity group wrap state to action container so Add to Cart switches layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a34cd824832db9e1179c36bdfe76