### PR TITLE
ATC (colecții) — auto-width dreapta + 100% la wrap

### DIFF
--- a/assets/collection-quick-add.css
+++ b/assets/collection-quick-add.css
@@ -83,3 +83,35 @@ input.collection-qty-element:focus {
   font-weight: 600;
 }
 
+/* == Layout container acțiuni pe colecții == */
+[data-collection-cart-actions] {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: .5rem;
+}
+
+/* Grupul qty = fluid; permite ATC să se alinieze la dreapta */
+[data-collection-cart-actions] .collection-qty-wrapper {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* Varianta NORMALĂ (un singur rând): ATC auto-width, lipit dreapta */
+[data-collection-cart-actions]:not(.is-stacked) .collection-add-to-cart {
+  width: auto !important;       /* anulează w-full din markup */
+  margin-left: auto;            /* împinge la dreapta */
+  margin-top: 0 !important;     /* anulează mt-4 doar în modul inline */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: max(128px, fit-content);
+}
+
+/* Varianta WRAP (două rânduri): ATC full width sub grup */
+[data-collection-cart-actions].is-stacked .collection-add-to-cart {
+  width: 100% !important;
+  margin-left: 0;
+  margin-top: .75rem !important; /* o treaptă de spațiu când e pe rând separat */
+}
+

--- a/assets/collection-quick-add.js
+++ b/assets/collection-quick-add.js
@@ -897,3 +897,46 @@ async function handleDelegatedAddToCart(e){
   }
 })();
 
+(function() {
+  const QTY_GROUP_SEL = '[data-collection-cart-actions] .collection-qty-group';
+  const ACTIONS_SEL   = '[data-collection-cart-actions]';
+
+  function isWrapped(el) {
+    // Heuristică stabilă: dacă primul și ultimul copil au Y diferit => wrap
+    const kids = Array.from(el.children).filter(n => n.offsetParent !== null);
+    if (kids.length < 2) return false;
+    const top0 = kids[0].getBoundingClientRect().top;
+    const topN = kids[kids.length - 1].getBoundingClientRect().top;
+    return Math.abs(topN - top0) > 2; // >2px pentru zgomot layout
+  }
+
+  function updateStackStateFor(el) {
+    const actions = el.closest(ACTIONS_SEL);
+    if (!actions) return;
+    const wrapped = isWrapped(el);
+    actions.classList.toggle('is-stacked', wrapped);
+  }
+
+  function scanAll() {
+    document.querySelectorAll(QTY_GROUP_SEL).forEach(el => updateStackStateFor(el));
+  }
+
+  // Init pe DOM ready
+  document.addEventListener('DOMContentLoaded', () => {
+    requestAnimationFrame(scanAll);
+    // Resize global
+    window.addEventListener('resize', () => requestAnimationFrame(scanAll), { passive: true });
+  });
+
+  // Re-scan pentru evenimente Shopify/temă frecvente
+  ['shopify:section:load', 'cart:updated', 'product:updated'].forEach(evt =>
+    document.addEventListener(evt, () => requestAnimationFrame(scanAll))
+  );
+
+  // Observă containerul pentru schimbări dinamice de dimensiuni (slidere, font-load, img)
+  try {
+    const ro = new ResizeObserver(() => requestAnimationFrame(scanAll));
+    document.querySelectorAll(ACTIONS_SEL).forEach(node => ro.observe(node));
+  } catch (e) { /* optional pe browsere vechi */ }
+})();
+


### PR DESCRIPTION
## Summary
- Align collection ATC button to the right with auto width when actions fit on one line
- Expand ATC button to full width and stack when quantity controls wrap
- Detect wrapping via ResizeObserver and sync `.is-stacked` class across events

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7aa4a3c38832daa7f9aed2e0f41a0