### PR TITLE
Align add-to-cart button with quantity group

### DIFF
--- a/assets/double-qty.css
+++ b/assets/double-qty.css
@@ -44,3 +44,26 @@
   }
 }
 
+/* Layout tweaks for product page quantity group */
+.product-qty-group {
+  flex-wrap: wrap;
+}
+.product-qty-group .quantity-input {
+  flex: 0 0 auto;
+  width: auto;
+}
+.product-qty-group .double-qty-btn {
+  flex: 0 0 auto;
+  width: auto;
+  max-width: 160px;
+}
+.product-qty-group.is-wrapped .quantity-input,
+.product-qty-group.is-wrapped .double-qty-btn {
+  flex: 1 1 100%;
+  width: 100%;
+}
+.product-qty-group.is-wrapped .double-qty-btn {
+  max-width: none;
+  height: 46px;
+}
+

--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -390,6 +390,35 @@ var BUTTON_CLASS = 'double-qty-btn';
       if(btn) btn.classList.remove('focus');
     }
 
+    function updateProductQtyLayout(){
+      document.querySelectorAll('.product-qty-group').forEach(function(group){
+        var input = group.querySelector('input[data-quantity-input]');
+        var btn = group.querySelector('.double-qty-btn');
+        var cart = group.closest('[data-cart-actions]');
+        var atc = cart && cart.querySelector('.add-to-cart');
+        if(!input || !btn || !atc) return;
+        var wrapped = btn.offsetTop > input.offsetTop;
+        group.classList.toggle('is-wrapped', wrapped);
+        if(wrapped){
+          atc.classList.add('w-full','mt-4');
+          atc.classList.remove('ml-auto');
+          atc.style.flexGrow = '1';
+        }else{
+          atc.classList.remove('w-full','mt-4');
+          atc.classList.add('ml-auto');
+          atc.style.flexGrow = '0';
+        }
+      });
+    }
+
+    var qtyLayoutBound = false;
+    function watchProductQtyLayout(){
+      updateProductQtyLayout();
+      if(qtyLayoutBound) return;
+      qtyLayoutBound = true;
+      window.addEventListener('resize', updateProductQtyLayout);
+    }
+
     document.addEventListener('input', handleQtyInputEvent, true);
     document.addEventListener('change', handleQtyInputEvent, true);
     document.addEventListener('blur', handleQtyInputEvent, true);
@@ -402,6 +431,7 @@ var BUTTON_CLASS = 'double-qty-btn';
       applyMinQty();
       setupDoubleQtyButtons();
       attachQtyButtonListeners();
+      watchProductQtyLayout();
     }
     document.addEventListener('DOMContentLoaded', initAll);
     window.addEventListener('shopify:section:load', initAll);

--- a/snippets/product-form.liquid
+++ b/snippets/product-form.liquid
@@ -77,7 +77,7 @@
 
           <div class="flex flex-wrap items-end{% unless has_double_qty_btn %} gap-2{% endunless %}">
             {% if show_quantity_selector == true %}
-              <div class="form__input-wrapper form__input-wrapper--select{% if has_double_qty_btn %} mr-5 w-32{% else %} flex-1{% endif %}" data-quantity-input-wrapper>
+              <div class="form__input-wrapper form__input-wrapper--select{% if has_double_qty_btn %} mr-5{% else %} flex-1{% endif %}" data-quantity-input-wrapper>
                 {% render 'product-qty-input', product_form_id: product_form_id, show_double_qty_btn: show_double_qty_btn %}
               </div>
             {% endif %}

--- a/snippets/product-qty-input.liquid
+++ b/snippets/product-qty-input.liquid
@@ -1,7 +1,7 @@
 {% comment %}Quantity selector and optional "Add minimum quantity" button{% endcomment %}
-<div class="flex gap-2 w-full">
+<div class="product-qty-group flex flex-wrap gap-2">
   {%- assign qty_input_id = product_form_id | append: '-qty' -%}
-  <quantity-input class="quantity-input h-[46px] flex border border-color-border rounded flex-1 {{ class }}" data-product-id="{{ product.id }}">
+  <quantity-input class="quantity-input h-[46px] flex border border-color-border rounded {% if show_double_qty_btn %}flex-none{% else %}flex-1{% endif %} {{ class }}" data-product-id="{{ product.id }}">
     <button
         class="quantity-input__button flex items-center justify-center h-[46px] w-[46px]"
         type="button"
@@ -51,7 +51,7 @@
     {%- if min_qty > 0 and inventory_qty > 0 or request.design_mode -%}
       <button
         type="button"
-        class="double-qty-btn sf__btn sf__btn-secondary flex-1 max-w-[160px]"
+        class="double-qty-btn sf__btn sf__btn-secondary flex-none max-w-[160px]"
         aria-label="{{ btn_label }}"
         data-double-qty
         data-label-template="{{ label_template }}"


### PR DESCRIPTION
## Summary
- Allow quantity selector and double-quantity button to wrap and stay on one line when space permits
- Dynamically switch add-to-cart button between inline auto width and full width on wrap

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ac70a658832d930a6bbd3a59db41