### PR TITLE
feat: make quick-add cart button inline when space permits

### DIFF
--- a/assets/collection-quick-add.css
+++ b/assets/collection-quick-add.css
@@ -83,3 +83,31 @@ input.collection-qty-element:focus {
   font-weight: 600;
 }
 
+/* Layout adjustments when qty group and "Adaugă încă" fit on one line */
+.collection-form__actions {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.collection-form__actions.inline-layout .collection-qty-wrapper,
+.collection-form__actions.inline-layout .collection-qty-group {
+  width: auto;
+  flex: 0 0 auto;
+}
+
+.collection-form__actions.inline-layout .collection-qty-group .collection-quantity-input,
+.collection-form__actions.inline-layout .collection-qty-group .collection-double-qty-btn {
+  flex: 0 0 auto;
+  width: auto;
+}
+
+.collection-form__actions.inline-layout .collection-qty-group .collection-double-qty-btn {
+  max-width: 160px;
+}
+
+.collection-form__actions.inline-layout .collection-add-to-cart {
+  width: auto;
+  margin-left: auto;
+  margin-top: 0;
+}
+

--- a/assets/collection-quick-add.js
+++ b/assets/collection-quick-add.js
@@ -681,9 +681,14 @@ async function handleDelegatedAddToCart(e){
   function updateQtyGroupLayout(){
     document.querySelectorAll('.collection-qty-group').forEach(function(group){
       var input = group.querySelector('input[data-collection-quantity-input]');
+      if(!input) return;
       var btn = group.querySelector('.collection-double-qty-btn');
-      if(!input || !btn) return;
-      group.classList.toggle('is-wrapped', btn.offsetTop > input.offsetTop);
+      var wrapped = btn ? (btn.offsetTop > input.offsetTop) : false;
+      group.classList.toggle('is-wrapped', wrapped);
+      var actions = group.closest('.collection-form__actions');
+      if(actions) {
+        actions.classList.toggle('inline-layout', !wrapped);
+      }
     });
   }
   var qtyLayoutListenerBound = false;


### PR DESCRIPTION
## Summary
- make `.collection-form__actions` flex and add `.inline-layout` state
- toggle inline layout in JS based on qty group wrapping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b04c3e44832db562f903725ac40b