### PR TITLE
Handle low-stock double quantity button

### DIFF
--- a/assets/collection-quick-add.js
+++ b/assets/collection-quick-add.js
@@ -78,11 +78,17 @@ function qgSyncSliderQtyUI(qtyEl, sendQty) {
   var card = qtyEl.closest('.sf__pcard, .p-card, .product-card, .sf__col-item, [data-product-id], .swiper-slide, [data-section-type]');
   var dbl  = card && (card.querySelector('[data-collection-double-qty]') || card.querySelector('.collection-double-qty-btn') || card.querySelector('.double-qty-btn'));
   if (dbl) {
-    var disabled = atMax;
+    var lowStock = max > 0 && max < step;
+    var disabled = atMax || lowStock;
     dbl.disabled = disabled;
     dbl.toggleAttribute('disabled', disabled);
     dbl.setAttribute('aria-disabled', String(disabled));
     dbl.classList.toggle('is-disabled', disabled);
+    if (lowStock) {
+      dbl.setAttribute('title', 'Stoc insuficient pentru cantitatea minimă');
+    } else {
+      dbl.removeAttribute('title');
+    }
   }
 
   // sincronizează duplicatele (dacă există utilitare)
@@ -139,15 +145,17 @@ function qgSyncSliderQtyUI(qtyEl, sendQty) {
     const card = input.closest('.sf__pcard, .p-card, .product-card, .sf__col-item, [data-product-id], .swiper-slide') || document;
     const dbl  = card.querySelector('[data-collection-double-qty], .collection-double-qty-btn, .double-qty-btn');
     if (dbl) {
-      const disabled = !(max >= step);
-      if (disabled) {
+      const lowStock = !(max >= step);
+      if (lowStock) {
         dbl.setAttribute('disabled', 'true');
         dbl.setAttribute('aria-disabled', 'true');
         dbl.classList.add('is-disabled');
+        dbl.setAttribute('title', 'Stoc insuficient pentru cantitatea minimă');
       } else {
         dbl.removeAttribute('disabled');
         dbl.removeAttribute('aria-disabled');
         dbl.classList.remove('is-disabled');
+        dbl.removeAttribute('title');
       }
     }
 
@@ -269,7 +277,9 @@ function qgSyncSliderQtyUI(qtyEl, sendQty) {
       // Allow user to clear the field while typing. Only enforce the
       // minimum quantity when the value is not empty.
       if (e.type === 'input' && input.value === '') {
+        var step = parseInt(input.getAttribute('data-collection-min-qty') || input.step || '1', 10) || 1;
         var max  = parseInt(input.getAttribute('max') || input.max || '0', 10) || 0;
+        var lowStock = isFinite(max) && max < step;
         input.classList.remove('text-red-600');
         input.style.removeProperty('color');
 
@@ -277,18 +287,23 @@ function qgSyncSliderQtyUI(qtyEl, sendQty) {
         if (wrap) {
           var plus  = wrap.querySelector('[data-collection-quantity-selector="increase"]');
           var minus = wrap.querySelector('[data-collection-quantity-selector="decrease"]');
-          if (plus)  plus.disabled  = isFinite(max) && max <= 0;
+          if (plus)  plus.disabled  = lowStock;
           if (minus) minus.disabled = true;
         }
 
         var card = input.closest('.sf__pcard, .p-card, .product-card, .sf__col-item, [data-product-id], .swiper-slide, [data-section-type]');
         var dbl  = card && (card.querySelector('[data-collection-double-qty]') || card.querySelector('.collection-double-qty-btn') || card.querySelector('.double-qty-btn'));
         if (dbl) {
-          var disabled = isFinite(max) && max <= 0;
+          var disabled = lowStock;
           dbl.disabled = disabled;
           dbl.toggleAttribute('disabled', disabled);
           dbl.setAttribute('aria-disabled', String(disabled));
           dbl.classList.toggle('is-disabled', disabled);
+          if (lowStock) {
+            dbl.setAttribute('title', 'Stoc insuficient pentru cantitatea minimă');
+          } else {
+            dbl.removeAttribute('title');
+          }
         }
         return;
       }
@@ -455,7 +470,17 @@ function qgSyncSliderQtyUI(qtyEl, sendQty) {
     btn.textContent = label;
     var max = input.max ? parseInt(input.max,10) : 9999;
     var val = parseInt(input.value,10) || 1;
-    btn.disabled = val >= max;
+    var lowStock = max > 0 && max < min;
+    var disabled = val >= max || lowStock;
+    btn.disabled = disabled;
+    btn.toggleAttribute('disabled', disabled);
+    btn.setAttribute('aria-disabled', String(disabled));
+    btn.classList.toggle('is-disabled', disabled);
+    if (lowStock) {
+      btn.setAttribute('title', 'Stoc insuficient pentru cantitatea minimă');
+    } else {
+      btn.removeAttribute('title');
+    }
   }
 
   function setupCollectionDoubleQtyButtons(){

--- a/assets/slider-qty-enforcer.js
+++ b/assets/slider-qty-enforcer.js
@@ -42,15 +42,17 @@
     const card = input.closest('.sf__pcard, .p-card, .product-card, .sf__col-item, [data-product-id], .swiper-slide') || document;
     const dbl  = card.querySelector('[data-collection-double-qty], .collection-double-qty-btn, .double-qty-btn');
     if (dbl){
-      const disabled = !(maxAttr >= stepAttr);
-      if (disabled){
+      const lowStock = !(maxAttr >= stepAttr);
+      if (lowStock){
         dbl.setAttribute('disabled','true');
         dbl.setAttribute('aria-disabled','true');
         dbl.classList.add('is-disabled');
+        dbl.setAttribute('title','Stoc insuficient pentru cantitatea minimă');
       } else {
         dbl.removeAttribute('disabled');
         dbl.removeAttribute('aria-disabled');
         dbl.classList.remove('is-disabled');
+        dbl.removeAttribute('title');
       }
     }
   }

--- a/snippets/collection-quick-add.liquid
+++ b/snippets/collection-quick-add.liquid
@@ -41,7 +41,7 @@
                     <svg class="w-[12px] h-[12px]" fill="currentColor" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path d="M376 232H216V72c0-4.42-3.58-8-8-8h-32c-4.42 0-8 3.58-8 8v160H8c-4.42 0-8 3.58-8 8v32c0 4.42 3.58 8 8 8h160v160c0 4.42 3.58 8 8 8h32c4.42 0 8-3.58 8-8V280h160c4.42 0 8-3.58 8-8v-32c0-4.42-3.58-8-8-8z"/></svg>
                   </button>
                 </collection-quantity-input>
-                {%- if min_qty > 0 and max_qty > 0 or request.design_mode -%}
+                {%- if min_qty > 0 or request.design_mode -%}
                   <button type="button" class="collection-double-qty-btn double-qty-btn sf__btn sf__btn-secondary flex-1 max-w-[160px] h-[46px]" aria-label="{{ double_label }}" data-collection-double-qty data-collection-label-template="{{ label_template }}" data-collection-original-min-qty="{{ min_qty }}" data-collection-product-id="{{ product.id }}">{{ double_label }}</button>
                 {%- endif -%}
               </div>


### PR DESCRIPTION
## Summary
- Always render collection double quantity button regardless of stock
- Disable double quantity button with tooltip when stock is below minimum on collection pages and sliders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d7d048dc832dbdbe35a4107bc7c9