### PR TITLE
feat: compact add-to-cart when qty controls inline

### DIFF
--- a/assets/collection-quick-add.css
+++ b/assets/collection-quick-add.css
@@ -85,6 +85,7 @@ input.collection-qty-element:focus {
 
 /* compact Add to cart layout when quantity controls stay on one line */
 .collection-form__actions.add-to-cart--compact .collection-add-to-cart {
+  display: block;
   width: auto;
   margin-left: auto;
   flex-grow: 0;

--- a/assets/collection-quick-add.css
+++ b/assets/collection-quick-add.css
@@ -83,3 +83,10 @@ input.collection-qty-element:focus {
   font-weight: 600;
 }
 
+/* compact Add to cart layout when quantity controls stay on one line */
+.collection-form__actions.add-to-cart--compact .collection-add-to-cart {
+  width: auto;
+  margin-left: auto;
+  flex-grow: 0;
+}
+

--- a/assets/collection-quick-add.js
+++ b/assets/collection-quick-add.js
@@ -707,8 +707,14 @@ async function handleDelegatedAddToCart(e){
     document.querySelectorAll('.collection-qty-group').forEach(function(group){
       var input = group.querySelector('input[data-collection-quantity-input]');
       var btn = group.querySelector('.collection-double-qty-btn');
-      if(!input || !btn) return;
-      group.classList.toggle('is-wrapped', btn.offsetTop > input.offsetTop);
+      var actions = group.closest('.collection-form__actions');
+      if(!input || !btn){
+        if(actions) actions.classList.remove('add-to-cart--compact');
+        return;
+      }
+      var wrapped = btn.offsetTop > input.offsetTop;
+      group.classList.toggle('is-wrapped', wrapped);
+      if(actions) actions.classList.toggle('add-to-cart--compact', !wrapped);
     });
   }
   var qtyLayoutListenerBound = false;


### PR DESCRIPTION
## Summary
- shrink collection add-to-cart button when quantity controls stay on one line
- restore full-width layout when quantity wraps or double-qty button missing

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9002fa504832da657830cd5b7ff4f