### PR TITLE
feat: add :has selector for quick-add layout

### DIFF
--- a/assets/collection-quick-add.css
+++ b/assets/collection-quick-add.css
@@ -84,7 +84,8 @@ input.collection-qty-element:focus {
 }
 
 /* compact Add to cart layout when quantity controls stay on one line */
-.collection-form__actions.add-to-cart--compact .collection-add-to-cart {
+.collection-form__actions.add-to-cart--compact .collection-add-to-cart,
+.collection-form__actions:has(.collection-qty-group:not(.is-wrapped) .collection-double-qty-btn) .collection-add-to-cart {
   display: block;
   width: auto;
   margin-left: auto;

--- a/assets/collection-quick-add.js
+++ b/assets/collection-quick-add.js
@@ -4,6 +4,7 @@
  */
 (function(){
   var addToCartLocks = new WeakSet();
+  var supportsHasSelector = typeof CSS !== 'undefined' && CSS.supports && CSS.supports('selector(:has(*))');
   function snapDown(val, step, min){
     if(!isFinite(val)) return min;
     if(val < min) return min;
@@ -709,12 +710,18 @@ async function handleDelegatedAddToCart(e){
       var btn = group.querySelector('.collection-double-qty-btn');
       var actions = group.closest('.collection-form__actions');
       if(!input || !btn){
-        if(actions) actions.classList.remove('add-to-cart--compact');
+        if(actions && !supportsHasSelector) actions.classList.remove('add-to-cart--compact');
         return;
       }
       var wrapped = btn.offsetTop > input.offsetTop;
       group.classList.toggle('is-wrapped', wrapped);
-      if(actions) actions.classList.toggle('add-to-cart--compact', !wrapped);
+      if(actions){
+        if(supportsHasSelector){
+          actions.classList.remove('add-to-cart--compact');
+        }else{
+          actions.classList.toggle('add-to-cart--compact', !wrapped);
+        }
+      }
     });
   }
   var qtyLayoutListenerBound = false;


### PR DESCRIPTION
## Summary
- use :has() selector so add-to-cart compact mode can be applied with pure CSS when qty group doesn't wrap
- add JS detection for :has support and only toggle compact class when needed, with wrap detector running after product append

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a70a5a4c832db281e281072b43b6