### PR TITLE
Ensure collection add-to-cart layout updates after resource load

### DIFF
--- a/assets/collection-quick-add.js
+++ b/assets/collection-quick-add.js
@@ -734,7 +734,7 @@ async function handleDelegatedAddToCart(e){
   var qtyLayoutListenerBound = false;
   function watchQtyGroupLayout(){
     updateQtyGroupLayout();
-    var container = document.querySelector('.sf-collection-list, .collection-listing');
+    var container = document.querySelector('[data-product-container]') || document.querySelector('.sf-collection-list, .collection-listing');
     if(container) bindQtyGroupImages(container);
     if(qtyLayoutListenerBound) return;
     qtyLayoutListenerBound = true;
@@ -743,6 +743,14 @@ async function handleDelegatedAddToCart(e){
     if(document.fonts){
       document.fonts.ready && document.fonts.ready.then(updateQtyGroupLayout).catch(function(){});
       document.fonts.addEventListener && document.fonts.addEventListener('loadingdone', updateQtyGroupLayout);
+    }
+    if(window.ConceptSGMEvents && typeof window.ConceptSGMEvents.subscribe === 'function'){
+      window.ConceptSGMEvents.subscribe('ON_PRODUCT_LIST_UPDATED', function(){
+        updateQtyGroupLayout();
+        setupCollectionDoubleQtyButtons();
+        var container = document.querySelector('[data-product-container]') || document.querySelector('.sf-collection-list, .collection-listing');
+        if(container) bindQtyGroupImages(container);
+      });
     }
     if(container && window.MutationObserver){
       var observer = new MutationObserver(function(mutations){

--- a/assets/collection-quick-add.js
+++ b/assets/collection-quick-add.js
@@ -717,13 +717,33 @@ async function handleDelegatedAddToCart(e){
       if(actions) actions.classList.toggle('add-to-cart--compact', !wrapped);
     });
   }
+  function bindQtyGroupImages(root){
+    if(!root) return;
+    var imgs = [];
+    if(root.matches && root.matches('img')) imgs.push(root);
+    if(root.querySelectorAll){
+      root.querySelectorAll('img').forEach(function(img){ imgs.push(img); });
+    }
+    imgs.forEach(function(img){
+      if(img.__qtyImgBound) return;
+      img.__qtyImgBound = true;
+      img.addEventListener('load', updateQtyGroupLayout);
+      img.addEventListener('error', updateQtyGroupLayout);
+    });
+  }
   var qtyLayoutListenerBound = false;
   function watchQtyGroupLayout(){
     updateQtyGroupLayout();
+    var container = document.querySelector('.sf-collection-list, .collection-listing');
+    if(container) bindQtyGroupImages(container);
     if(qtyLayoutListenerBound) return;
     qtyLayoutListenerBound = true;
     window.addEventListener('resize', updateQtyGroupLayout);
-    var container = document.querySelector('.sf-collection-list, .collection-listing');
+    window.addEventListener('load', updateQtyGroupLayout);
+    if(document.fonts){
+      document.fonts.ready && document.fonts.ready.then(updateQtyGroupLayout).catch(function(){});
+      document.fonts.addEventListener && document.fonts.addEventListener('loadingdone', updateQtyGroupLayout);
+    }
     if(container && window.MutationObserver){
       var observer = new MutationObserver(function(mutations){
         updateQtyGroupLayout();
@@ -738,6 +758,7 @@ async function handleDelegatedAddToCart(e){
             root.querySelectorAll && root.querySelectorAll('input.collection-qty-element[data-collection-quantity-input]').forEach(function(inp){
               if(qgIsSliderInput(inp)) qgEnforceSliderInput(inp);
             });
+            bindQtyGroupImages(root);
           });
         });
       });


### PR DESCRIPTION
## Summary
- Recalculate collection quick-add layout when images or fonts load
- Attach load listeners to dynamically added products and assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c8b2b4b0832d92c6f44dcec20a23