### PR TITLE
feat: prevent add-to-cart flicker on collection

### DIFF
--- a/assets/collection-quick-add.js
+++ b/assets/collection-quick-add.js
@@ -4,6 +4,17 @@
  */
 (function(){
   var addToCartLocks = new WeakSet();
+  var qgFirstPaintDone = false;
+  function qgMarkListingReady(){
+    if(qgFirstPaintDone) return;
+    var listing = document.querySelector('.sf__product-listing[data-product-container]');
+    if(listing){
+      listing.setAttribute('data-qg-ready','1');
+    }
+    // Fallback global (dacă nu există containerul dintr-un motiv sau altul)
+    try { document.documentElement.removeAttribute('data-qg'); } catch(e){}
+    qgFirstPaintDone = true;
+  }
   function snapDown(val, step, min){
     if(!isFinite(val)) return min;
     if(val < min) return min;
@@ -725,9 +736,14 @@ async function handleDelegatedAddToCart(e){
   var qtyResizeObserver = window.ResizeObserver ? new ResizeObserver(updateQtyGroupLayout) : null;
   function watchQtyGroupLayout(){
     updateQtyGroupLayout();
+    qgMarkListingReady(); // <- marchează containerul ca ready imediat după prima măsurare
     if(qtyLayoutListenerBound) return;
     qtyLayoutListenerBound = true;
     window.addEventListener('resize', updateQtyGroupLayout);
+    window.addEventListener('load', function(){ updateQtyGroupLayout(); qgMarkListingReady(); });
+    if(document.fonts && document.fonts.ready){
+      document.fonts.ready.then(function(){ updateQtyGroupLayout(); qgMarkListingReady(); });
+    }
     var container = document.querySelector('[data-product-container]');
     if(container && qtyResizeObserver){
       container.querySelectorAll('.collection-qty-group').forEach(function(group){
@@ -737,6 +753,7 @@ async function handleDelegatedAddToCart(e){
     if(container && window.MutationObserver){
       var observer = new MutationObserver(function(mutations){
         updateQtyGroupLayout();
+        qgMarkListingReady(); // în caz că primul paint se întâmplă după primul append
         mutations.forEach(function(m){
           m.addedNodes.forEach(function(node){
             if(!(node instanceof HTMLElement)) return;
@@ -779,6 +796,9 @@ async function handleDelegatedAddToCart(e){
     attachQtyButtonListeners();
     attachNoHighlightListeners();
     watchQtyGroupLayout();
+    // Dacă initAll rulează din alte evenimente (ex. shopify:section:load),
+    // asigură-te că marcăm ready după prima măsurare:
+    qgMarkListingReady();
   }
   document.addEventListener('DOMContentLoaded', initAll);
   window.addEventListener('shopify:section:load', initAll);

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -41,6 +41,18 @@ template-{{ template.name | handle }} {{ template.name }}-{{ template.suffix }} 
   {% render 'critical-scripts' %}
   {% render 'custom-code-head' %}
 
+  {%- comment -%} QG critical gate: elimină FOUC pe collection quick-add {%- endcomment -%}
+  <style id="qg-critical">
+    /* Ascunde DOAR acțiunile din listing de colecții până la prima măsurare.
+       Folosim visibility:hidden ca să nu provoace layout shift. */
+    html[data-qg="init"] .sf__product-listing[data-product-container]:not([data-qg-ready])
+    .collection-form__actions { visibility: hidden; }
+  </style>
+  <script>
+    // Setăm cât mai devreme posibil ca să prindem primul paint.
+    try { document.documentElement.setAttribute('data-qg','init'); } catch(e){}
+  </script>
+
   {{ 'theme.css' | asset_url | stylesheet_tag }}
   {{ 'chunk.css' | asset_url | stylesheet_tag }}
 


### PR DESCRIPTION
## Summary
- inject quick-add critical gate in head to hide collection actions until layout ready
- mark product listing ready after first measurement to avoid FOUC

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ea129b80832db0ebd0456969f21c